### PR TITLE
Update liquids.lua

### DIFF
--- a/util/liquids.lua
+++ b/util/liquids.lua
@@ -19,7 +19,7 @@ local water_texture = "default_water.png"
 local river_water_texture = "default_river_water.png"
 
 local mcla = minetest.get_game_info().id == "mineclonia"
-local mcl2 = minetest.get_game_info().id == "mineclone2"
+local mcl2 = minetest.get_game_info().id == "VoxeLibre"
 if mcla then
   lava_texture = "default_lava_source_animated.png^[sheet:1x16:0,0"
   water_texture = "default_water_source_animated.png^[sheet:1x16:0,0"


### PR DESCRIPTION
Fix the game info id since it doesn't work since the mineclone2 project change name, creating texture error messages at the start of the game.

Tested on my server, this remove the error messages, so it should be OK.