### PR TITLE
Override has_crafting_table from mineclonia to fix AP crafting grid not working in Mineclonia

### DIFF
--- a/logic/access_point_formspec.lua
+++ b/logic/access_point_formspec.lua
@@ -462,3 +462,7 @@ function logistica.access_point_on_dug(pos)
     logistica.access_point_on_player_leave(playerName)
   end
 end
+
+function logistica.access_point_is_player_using_ap(playerName)
+  return accessPointForms[playerName] ~= nil
+end

--- a/util/compat_mcl.lua
+++ b/util/compat_mcl.lua
@@ -53,3 +53,15 @@ logistica.itemstrings = {
     lava_source = mcl and "mcl_core:lava_source" or "default:lava_source",
     paper = mcl and "mcl_core:paper" or "default:paper"
 }
+
+-- function overrides
+if mcl_crafting_table and mcl_crafting_table.has_crafting_table and type(mcl_crafting_table.has_crafting_table) == "function" then
+  local has_crafting_table_orig = mcl_crafting_table.has_crafting_table
+  mcl_crafting_table.has_crafting_table = function(player)
+    if logistica.access_point_is_player_using_ap(player:get_player_name()) then
+      return true
+    else
+      return has_crafting_table_orig(player)
+    end
+  end
+end


### PR DESCRIPTION
This is to solve the issue: https://github.com/ZenonSeth/logistica/issues/16

Added an override to Mineclonia's `has_crafting_table` function in order to fix the Access Point's crafting grid not working when Logistica is used with Mineclonia.