### PR TITLE
Check to prevent wap from opening on chests

### DIFF
--- a/tools/wireless_access_pad.lua
+++ b/tools/wireless_access_pad.lua
@@ -50,6 +50,16 @@ end
 
 local function on_wireless_pad_secondary(itemstack, placer, pointed_thing)
   if not placer or not placer:is_player() then return end
+  -- Make sure the wap doesn't open if clicking on a node with on_rightclick function
+  -- unless sneak is pressed.
+  if pointed_thing.type == "node" then
+    local node = minetest.get_node(pointed_thing.under)
+    if not placer:get_player_control().sneak and node then
+      if minetest.registered_nodes[node.name] and minetest.registered_nodes[node.name].on_rightclick then
+        return minetest.registered_nodes[node.name].on_rightclick(pointed_thing.under, node, placer, itemstack) or itemstack
+      end
+    end
+  end
 
   local playerName = placer:get_player_name()
   local itemMeta = itemstack:get_meta()


### PR DESCRIPTION
This should prevent the wap from opening on nodes that define their own on_rightclick function.
Mainly to be able to open chests while holding the WAP, hoping there will be not many side effects.

Give it a double check as I'm smashing keys most of the times.