### PR TITLE
minetest complains: set_string to string, hud_elem_type -> type

### DIFF
--- a/logic/access_point_formspec.lua
+++ b/logic/access_point_formspec.lua
@@ -325,7 +325,7 @@ function logistica.access_point_allow_take(inv, listname, index, _stack, player)
     -- either way, only allow taking up to stack max
     stack:set_count(math.min(stack:get_count(), stackMax))
     -- remove the sometimes manually added count display
-    stack:get_meta():set_string("count_meta", nil)
+    stack:get_meta():set_string("count_meta", "")
     if stackMax > 1 then
       local taken = ItemStack("")
       local acceptTaken = function(st) taken:add_item(st); return 0 end

--- a/util/hud.lua
+++ b/util/hud.lua
@@ -23,6 +23,7 @@ function logistica.show_popup(playerName, text, time, atBottom, scale)
     playerHud[playerName] = nil
   end
   local hudId = player:hud_add({
+    hud_elem_type = "text",
     type = "text",
     style     = 1,
     position  = position,

--- a/util/hud.lua
+++ b/util/hud.lua
@@ -23,7 +23,7 @@ function logistica.show_popup(playerName, text, time, atBottom, scale)
     playerHud[playerName] = nil
   end
   local hudId = player:hud_add({
-    hud_elem_type = "text",
+    type = "text",
     style     = 1,
     position  = position,
     offset    = offset,


### PR DESCRIPTION
Minetest 5.9 is verbose about setting a string to nil and HUD element type changing its key (I suppose that's what happened)
Seems to run fine on 5.8 too, altho not extensively tested.

Not sure why syncing ended up in the pull request, does it cause issues?