### PR TITLE
Make cobble gen usable on servers with Techage mod

### DIFF
--- a/api/cobble_supplier.lua
+++ b/api/cobble_supplier.lua
@@ -46,7 +46,7 @@ local function get_cobblegen_formspec(pos)
     "listring["..posForm..";"..INV_DST.."]"..
     "listring[current_player;main]"..
     "list["..posForm..";"..INV_DST..";2.9,1.1;2,1;0]"..
-    "label[0.4,0.5;"..FS("Generates Cobblestone and passively supplies it to Network").."]"..
+    "label[0.4,0.5;"..FS("Generates @1 and passively supplies it to Network", minetest.registered_items[COBBLESTONE].description).."]"..
     "image[6.6,1.1;1,1;logistica_icon_upgrade.png]"..
     "tooltip[6.6,1.1;1,1;"..UPGRADE_TOOLTIP.."]"
 end

--- a/guide/guide_content.lua
+++ b/guide/guide_content.lua
@@ -425,7 +425,7 @@ logistica.GuideApi.register(GUIDE_NAME, {
     },
 
     [PAGE_COBBLE_GENERATOR] = {
-      title = S("Cobblestone Generator"),
+      title = S("Cobble Generator"),
       relatedItems = {L("cobblegen_upgrade")},
       recipes = RECIPE_COBBLGEN,
       recipeLinks = RECIPE_LINKS,
@@ -450,7 +450,7 @@ logistica.GuideApi.register(GUIDE_NAME, {
     },
 
     [PAGE_COBBLE_GENERATOR_UPGR] = {
-      title = S("Cobblestone Generator Upgrades"),
+      title = S("Cobble Generator Upgrades"),
       relatedItems = {L("cobblegen_supplier")},
       recipes = RECIPE_COBGENUP,
       recipeLinks = RECIPE_LINKS,

--- a/guide/guide_desc_items.lua
+++ b/guide/guide_desc_items.lua
@@ -11,9 +11,9 @@ Note that you cannot remove Mass Storage upgrades from a Mass Storage machine if
 ]])
 
 g.cobblegen_upgrade = S([[
-Cobblestone Generator Upgrades are added the Cobble Generator Supplier.
+Cobble Generator Upgrades are added the Cobble Generator Supplier.
 
-Each upgrade doubles the rate of cobblestone output.
+Each upgrade doubles the rate of cobble output.
 ]])
 
 g.wireless_access_pad = S([[

--- a/locale/logistica.pot
+++ b/locale/logistica.pot
@@ -74,7 +74,7 @@ msgid ""
 msgstr ""
 
 #: api/cobble_supplier.lua:49
-msgid "Generates Cobblestone and passively supplies it to Network"
+msgid "Generates @1 and passively supplies it to Network"
 msgstr ""
 
 #: api/controller.lua:15
@@ -703,7 +703,7 @@ msgid "Lava Furnace Fueler"
 msgstr ""
 
 #: guide/guide_content.lua:428
-msgid "Cobblestone Generator"
+msgid "Cobble Generator"
 msgstr ""
 
 #: guide/guide_content.lua:436 registration/machines_api_reg.lua:283
@@ -715,7 +715,7 @@ msgid "Mass Storage Upgrades"
 msgstr ""
 
 #: guide/guide_content.lua:453
-msgid "Cobblestone Generator Upgrades"
+msgid "Cobble Generator Upgrades"
 msgstr ""
 
 #: guide/guide_content.lua:463
@@ -864,9 +864,9 @@ msgstr ""
 
 #: guide/guide_desc_items.lua:13
 msgid ""
-"Cobblestone Generator Upgrades are added the Cobble Generator Supplier.\n"
+"Cobble Generator Upgrades are added the Cobble Generator Supplier.\n"
 "\n"
-"Each upgrade doubles the rate of cobblestone output.\n"
+"Each upgrade doubles the rate of cobble output.\n"
 msgstr ""
 
 #: guide/guide_desc_items.lua:19

--- a/locale/logistica.ru.po
+++ b/locale/logistica.ru.po
@@ -77,8 +77,8 @@ msgid ""
 msgstr "Слоты улучшений: 2 слота справа для улучшений генератора булыжника."
 
 #: api/cobble_supplier.lua:49
-msgid "Generates Cobblestone and passively supplies it to Network"
-msgstr "Генерирует булыжник и пассивно поставляет его в сеть"
+msgid "Generates @1 and passively supplies it to Network"
+msgstr "Генерирует @1 и пассивно поставляет его в сеть"
 
 #: api/controller.lua:15
 msgid "Network Name"
@@ -745,7 +745,7 @@ msgid "Lava Furnace Fueler"
 msgstr "Заправщик лавовой печи"
 
 #: guide/guide_content.lua:428
-msgid "Cobblestone Generator"
+msgid "Cobble Generator"
 msgstr "Генератор булыжника"
 
 #: guide/guide_content.lua:436 registration/machines_api_reg.lua:283
@@ -757,7 +757,7 @@ msgid "Mass Storage Upgrades"
 msgstr "Улучшения массового хранилища"
 
 #: guide/guide_content.lua:453
-msgid "Cobblestone Generator Upgrades"
+msgid "Cobble Generator Upgrades"
 msgstr "Улучшения генератора булыжника"
 
 #: guide/guide_content.lua:463
@@ -980,9 +980,9 @@ msgstr ""
 
 #: guide/guide_desc_items.lua:13
 msgid ""
-"Cobblestone Generator Upgrades are added the Cobble Generator Supplier.\n"
+"Cobble Generator Upgrades are added the Cobble Generator Supplier.\n"
 "\n"
-"Each upgrade doubles the rate of cobblestone output.\n"
+"Each upgrade doubles the rate of cobble output.\n"
 msgstr ""
 "Улучшения Генератора булыжника вставляются в соответствующую машину.\n"
 "\n"

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = logistica
-optional_depends = default, bucket, i3, mcl_core, mcl_buckets, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, bucket_wooden
+optional_depends = default, bucket, i3, mcl_core, mcl_buckets, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, bucket_wooden, techage
 min_minetest_version = 5.4.0
 author = ZenonSeth
 description = On-demand Item Transportation + Powerful Item and Liquid Storage

--- a/registration/item_recipes.lua
+++ b/registration/item_recipes.lua
@@ -105,7 +105,8 @@ end
 minetest.register_craft({
   output = L("cobblegen_upgrade"),
   recipe = {
-    {L("silverin_plate"), itemstrings.lava_bucket,  L("silverin_plate")},
+    {"",                  itemstrings.lava_bucket,  ""},
+    {L("silverin_plate"), itemstrings.nodebreaker,  L("silverin_plate")},
     {"",                  itemstrings.water_bucket, ""},
   },
   replacements = {

--- a/registration/item_recipes.lua
+++ b/registration/item_recipes.lua
@@ -105,9 +105,8 @@ end
 minetest.register_craft({
   output = L("cobblegen_upgrade"),
   recipe = {
-    {"",                  itemstrings.lava_bucket,  ""},
-    {L("silverin_plate"), itemstrings.nodebreaker,  L("silverin_plate")},
-    {"",                  itemstrings.water_bucket, ""},
+    {L("silverin_plate"), itemstrings.lava_bucket,  L("silverin_plate")},
+    {"",                  itemstrings.water_bucket, itemstrings.cobgen_upgr_additional},
   },
   replacements = {
     {itemstrings.water_bucket,  itemstrings.empty_bucket},

--- a/registration/node_recipes.lua
+++ b/registration/node_recipes.lua
@@ -131,7 +131,7 @@ minetest.register_craft({
   output = L("cobblegen_supplier"),
   recipe = {
     {L("silverin_plate"), itemstrings.lava_bucket,  L("silverin_plate")},
-    {L("optic_cable"),    L("photonizer"),          L("silverin_circuit")},
+    {L("optic_cable"),    L("photonizer"),          itemstrings.nodebreaker},
     {L("silverin_plate"), itemstrings.water_bucket, L("silverin_plate")},
   },
   replacements = {

--- a/util/compat_techage.lua
+++ b/util/compat_techage.lua
@@ -1,0 +1,6 @@
+local itemstrings = logistica.itemstrings
+local techage = minetest.get_modpath("techage")
+
+assert(type(itemstrings) == "table")
+
+if techage then itemstrings.cobble = "techage:basalt_cobble" end

--- a/util/compat_techage.lua
+++ b/util/compat_techage.lua
@@ -1,6 +1,9 @@
+local function L(s) return "logistica:"..s end
+
 local itemstrings = logistica.itemstrings
 local techage = minetest.get_modpath("techage")
 
 assert(type(itemstrings) == "table")
 
 if techage then itemstrings.cobble = "techage:basalt_cobble" end
+itemstrings.nodebreaker = techage and "techage:ta4_quarry_pas" or L("silverin_circuit")

--- a/util/compat_techage.lua
+++ b/util/compat_techage.lua
@@ -5,5 +5,11 @@ local techage = minetest.get_modpath("techage")
 
 assert(type(itemstrings) == "table")
 
-if techage then itemstrings.cobble = "techage:basalt_cobble" end
-itemstrings.nodebreaker = techage and "techage:ta4_quarry_pas" or L("silverin_circuit")
+if techage then
+  itemstrings.cobble = "techage:basalt_cobble"
+  itemstrings.nodebreaker = "techage:ta4_quarry_pas" 
+  itemstrings.cobgen_upgr_additional = "techage:ta4_quarry_pas"
+else
+  itemstrings.nodebreaker = L("silverin_circuit")
+  itemstrings.cobgen_upgr_additional = ""
+end

--- a/util/util.lua
+++ b/util/util.lua
@@ -1,6 +1,7 @@
 local path = logistica.MODPATH.."/util"
 
 dofile(path.."/compat_mcl.lua")
+dofile(path.."/compat_techage.lua")
 dofile(path.."/compat_mesecons.lua")
 dofile(path.."/settings.lua")
 dofile(path.."/common.lua")


### PR DESCRIPTION
The Techage mod allows players to squeeze out additional ore from their excess cobblestone reserves. It also [replaces lava cooling result with `techage:basalt_stone`](https://github.com/joe7575/techage/blob/2018ea1549ceb21a9bfb25a7d85d5ad90d590477/items/basalt.lua#L17-L26), from which only coal and iron can be extracted. Thus, cobblestone becomes non-renewable resource.

This PR introduces the following changes:
- If `techage` mod is enabled:
    - Replace `cobblegen_supplier` output with Basalt Cobble.
    - Make `cobblegen_supplier` and `cobblegen_upgrade` crafting recipes
      more expensive by adding Quarry (a node breaker) as input.
- Rename Cobblestone Generator to Cobble Generator.

This (hopefully) allows the usage of `cobblegen_supplier` without significant
game balance issues.

**TODO:**
- [x] ~~When `techage` mod is disabled (due to server maintenance?) cobblegens will immediately start producing cobblestone again.~~