### PR TITLE
Fix for Issue 40: Make sure crafting suppliers handle recipe changes due to mod updates without crashing

### DIFF
--- a/api/crafting_supplier.lua
+++ b/api/crafting_supplier.lua
@@ -8,15 +8,7 @@ local INV_HOUT = "hout"
 
 local forms = {}
 
-local function update_craft_output(inv)
-  local inputList = logistica.get_list(inv, INV_CRAFT)
-  local out, _ = minetest.get_craft_result({
-    method = "normal",
-    width = 3,
-    items = inputList
-  })
-  inv:set_stack(INV_MAIN, 1, out.item)
-end
+
 
 local function get_craftsup_formspec(pos)
   local posForm = "nodemeta:"..pos.x..","..pos.y..","..pos.z
@@ -38,6 +30,8 @@ local function get_craftsup_formspec(pos)
 end
 
 local function show_craftsup_formspec(playerName, pos)
+  -- make sure we upate the output item
+  logistica.crafting_supplier_update_output(pos)
   forms[playerName] = {position = pos}
   minetest.show_formspec(playerName, FORMSPEC_NAME, get_craftsup_formspec(pos))
 end
@@ -87,8 +81,7 @@ local function allow_craftsup_storage_inv_put(pos, listname, index, stack, playe
     else
       inv:set_stack(listname, index, stack)
     end
-    update_craft_output(minetest.get_meta(pos):get_inventory())
-    logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+    logistica.crafting_supplier_update_output(pos)
   end
   return 0
 end
@@ -100,8 +93,7 @@ local function allow_craftsup_inv_take(pos, listname, index, stack, player)
     local st = inv:get_stack(listname, index)
     st:take_item(stack:get_count())
     inv:set_stack(listname, index, st)
-    update_craft_output(minetest.get_meta(pos):get_inventory())
-    logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+    logistica.crafting_supplier_update_output(pos)
     return 0
   elseif listname == INV_MAIN then
     if index == 1 then return 0
@@ -116,18 +108,15 @@ local function allow_craftsup_inv_move(pos, from_list, from_index, to_list, to_i
 end
 
 local function on_craftsup_inventory_put(pos, listname, index, stack, player)
-  update_craft_output(minetest.get_meta(pos):get_inventory())
-  logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+  logistica.crafting_supplier_update_output(pos)
 end
 
 local function on_craftsup_inventory_take(pos, listname, index, stack, player)
-  update_craft_output(minetest.get_meta(pos):get_inventory())
-  logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+  logistica.crafting_supplier_update_output(pos)
 end
 
 local function on_craftsup_inventory_move(pos, from_list, from_index, to_list, to_index, count, player)
-  update_craft_output(minetest.get_meta(pos):get_inventory())
-  logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+  logistica.crafting_supplier_update_output(pos)
 end
 
 local function can_dig_craftsup(pos, player)
@@ -141,7 +130,7 @@ end
 
 local function on_craftsup_power(pos, power)
   logistica.set_node_tooltip_from_state(pos, nil, power)
-  logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
+  logistica.crafting_supplier_update_output(pos)
 end
 
 ----------------------------------------------------------------

--- a/logic/crafting_supplier.lua
+++ b/logic/crafting_supplier.lua
@@ -85,6 +85,18 @@ local function consume_for_craft(craftItems, craftItemsMult, extrasMadeByCraftin
   return { countCanCraft = 1, newExtrasList = extrasCopy }
 end
 
+local function update_craft_output(inv)
+  local inputList = logistica.get_list(inv, INV_CRAFT)
+  local out, _ = minetest.get_craft_result({
+    method = "normal",
+    width = 3,
+    items = inputList
+  })
+  inv:set_stack(INV_MAIN, 1, out.item)
+end
+
+-- public functions
+
 -- returns a list of ItemStacks to be used for caching, which may be a sublist of INV_MAIN if the machine is off
 function logistica.crafting_supplier_get_main_list(pos)
   local isOn = logistica.is_machine_on(pos)
@@ -109,6 +121,9 @@ function logistica.take_item_from_crafting_supplier(pos, _takeStack, network, co
   local remaining = takeStack:get_count()
   local takeStackName = takeStack:get_name()
   local inv = minetest.get_meta(pos):get_inventory()
+
+  -- make sure we upate the output item
+  logistica.crafting_supplier_update_output(pos)
 
   -- first try to take from supply, ignore the 1st slot (which is for the crafted item)
   local supplierResult = logistica.take_item_from_supplier(pos, takeStack, network, collectorFunc, useMetadata, dryRun, 1)
@@ -195,4 +210,9 @@ function logistica.take_item_from_crafting_supplier(pos, _takeStack, network, co
   end
 
   return ret(remaining)
+end
+
+function logistica.crafting_supplier_update_output(pos)
+  update_craft_output(minetest.get_meta(pos):get_inventory())
+  logistica.update_cache_at_pos(pos, LOG_CACHE_SUPPLIER)
 end


### PR DESCRIPTION
## Previous behavior
When a recipe of an existing item changes due to a mod update, the crafting suppliers would cause a crash when that item was attempted to be taken (automatically or via access point)

## What has changed
- This change makes sure crafting suppliers update their output before attempting to craft items
- This should fix https://github.com/ZenonSeth/logistica/issues/40

## New behavior
Crafting suppliers will simply stop working if the item's recipe changed.