### PR TITLE
Fix issue #43 - VoxeLibre Nether lava could not be pumped by the Logistica pump

### DIFF
--- a/api/reservoir.lua
+++ b/api/reservoir.lua
@@ -194,12 +194,18 @@ end
   `liquidDesc`: a human readable liquid description, e.g. "Water"<br>
   `bucketItemName` : the name of the bucket that holds the liquid<br>
   `liquidTexture` : a single texture to use for the liquid<br>
-  `sourceBlockName` : the name of the minetest liquid source node
+  `sourceNodeName` : the name of the minetest liquid source node, or an array of them
   `optLight` : optional, if nil assumed 0. How much a non-empty reservoir will glow
   `emptyBucketName` : optional, if nil, bucket:bucket_empty will be used - the "empty" container to use<br>
 ]]
 function logistica.register_reservoir(liquidName, liquidDesc, bucketItemName, liquidTexture, sourceNodeName, optLight, optEmptyBucketName)
   local lname = string.lower(liquidName:gsub(" ", "_"))
+  local sourceNodeNames = nil
+  if type(sourceNodeName) == "string" then
+    sourceNodeNames = {sourceNodeName}
+  elseif type(sourceNodeName) == "table" then
+    sourceNodeNames = table.copy(sourceNodeName)
+  end
 
   for _, variantName in ipairs(variants) do
     local nodeName = L("reservoir_"..variantName.."_"..lname)
@@ -220,7 +226,7 @@ function logistica.register_reservoir(liquidName, liquidDesc, bucketItemName, li
         minetest.register_node(nodeName.."_disabled", get_disabled_def(def))
       end
 
-      logistica.reservoir_register_names(lname, bucketItemName, optEmptyBucketName, liquidDesc, liquidTexture, sourceNodeName)
+      logistica.reservoir_register_names(lname, bucketItemName, optEmptyBucketName, liquidDesc, liquidTexture, sourceNodeNames)
     end
   end
 end

--- a/logic/reservoir.lua
+++ b/logic/reservoir.lua
@@ -7,7 +7,7 @@ local EMPTY_TO_FILLED = {} -- { empty_bucket_name = { liquidName = full_bucket_n
 local NAME_TO_EMPTY_BUCKETS = {} -- { liquidName = { emptyBucket = true, ... } }
 local NAME_TO_DESC = {} -- { liquidName = "Description of liquid" }
 local NAME_TO_TEXTURE = {} -- { liquidName = "texture_of_liquid" }
-local NAME_TO_SOURCE = {} -- { liquidName = source_node_name }
+local NAME_TO_SOURCES = {} -- { liquidName = {[source_node_name_1] = true, [source_node_name_2] = true, ... } }
 local SOURCE_TO_NAME = {} -- { source_node_name = liquid_name }
 
 local EMPTY_BUCKET = logistica.itemstrings.empty_bucket
@@ -94,7 +94,7 @@ function logistica.reservoir_get_description(currBuckets, maxBuckets, liquidName
   return strDescription.."\n"..getStrContains(currBuckets, maxBuckets, liquidName)
 end
 
-function logistica.reservoir_register_names(liquidName, bucketName, emptyBucketName, liquidDesc, liquidTexture, sourceNodeName)
+function logistica.reservoir_register_names(liquidName, bucketName, emptyBucketName, liquidDesc, liquidTexture, sourceNodeNames)
   if not emptyBucketName then emptyBucketName = EMPTY_BUCKET end
 
   FILLED_BUCKET_TO_NAME[bucketName] = liquidName
@@ -112,9 +112,15 @@ function logistica.reservoir_register_names(liquidName, bucketName, emptyBucketN
 
   NAME_TO_DESC[liquidName] = liquidDesc
   NAME_TO_TEXTURE[liquidName] = liquidTexture
-  if sourceNodeName then
-    NAME_TO_SOURCE[liquidName] = sourceNodeName
-    SOURCE_TO_NAME[sourceNodeName] = liquidName
+  -- source node names is an array of source nodes associated with this liquid. Add the whole set.
+  if not NAME_TO_SOURCES[liquidName] then NAME_TO_SOURCES[liquidName] = {} end
+  if sourceNodeNames and type(sourceNodeNames) == "table" then
+    for _, sourceNodeName in ipairs(sourceNodeNames) do
+      if type(sourceNodeName) == "string" then
+        NAME_TO_SOURCES[liquidName][sourceNodeName] = true
+        SOURCE_TO_NAME[sourceNodeName] = liquidName
+      end
+    end
   end
 end
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = logistica
-optional_depends = default, bucket, i3, mcl_core, mcl_buckets, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, bucket_wooden, techage
+optional_depends = default, bucket, i3, mcl_core, mcl_buckets, mcl_nether, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, bucket_wooden, techage
 min_minetest_version = 5.4.0
 author = ZenonSeth
 description = On-demand Item Transportation + Powerful Item and Liquid Storage

--- a/util/compat_mcl.lua
+++ b/util/compat_mcl.lua
@@ -1,4 +1,5 @@
 local mcl = minetest.get_modpath("mcl_core")
+local mcl_nether = minetest.get_modpath("mcl_nether")
 
 logistica.sound_mod = mcl and mcl_sounds or default
 
@@ -6,6 +7,14 @@ local function get_mcl_river_water_source()
     if minetest.registered_nodes["mcl_core:river_water_source"] then return "mcl_core:river_water_source"
     elseif minetest.registered_nodes["mclx_core:river_water_source"] then return "mclx_core:river_water_source"
     else return "" end
+end
+
+local function get_mcl_lava_source_nether()
+    if minetest.registered_nodes["mcl_nether:nether_lava_source"] then
+        return "mcl_nether:nether_lava_source"
+    else
+        return nil
+    end
 end
 
 -- Returns a player's inventory formspec with the correct width and hotbar position for the current game
@@ -51,6 +60,7 @@ logistica.itemstrings = {
     water_source = mcl and "mcl_core:water_source" or "default:water_source",
     river_water_source = mcl and get_mcl_river_water_source() or "default:river_water_source",
     lava_source = mcl and "mcl_core:lava_source" or "default:lava_source",
+    lava_source_nether = mcl_nether and get_mcl_lava_source_nether() or nil,
     paper = mcl and "mcl_core:paper" or "default:paper"
 }
 

--- a/util/liquids.lua
+++ b/util/liquids.lua
@@ -36,8 +36,9 @@ liq.name_to_texture = {
   [liq.river_water] = river_water_texture,
 }
 
+-- Either to single source block or to list of source blocks.
 liq.name_to_source_block = {
-  [liq.lava] = itemstrings.lava_source,
+  [liq.lava] = {itemstrings.lava_source, itemstrings.lava_source_nether},
   [liq.water] = itemstrings.water_source,
   [liq.river_water] = itemstrings.river_water_source,
 }


### PR DESCRIPTION
### Fixes issue #43

Adds the ability to associate more than one source node with an abstract "liquid", and then adds `mcl_nether`'s lava source as another source for the lava liquid, when present.

This also preserves the reservoir part of the api functionality, by doing an automatic transform of single source block strings into the array format needed for the slightly modified internal logic.

Also, I fixed a variable name in some function docs ;p

