### PR TITLE
Disallowed invlists booster pack #1

### DIFF
--- a/util/compat_techage.lua
+++ b/util/compat_techage.lua
@@ -9,30 +9,6 @@ if techage then
   itemstrings.cobble = "techage:basalt_cobble"
   itemstrings.nodebreaker = "techage:ta4_quarry_pas" 
   itemstrings.cobgen_upgr_additional = "techage:ta4_quarry_pas"
-
-  local no_push = logistica.add_disallowed_push_list
-  local no_pull = logistica.add_disallowed_pull_list
-
-  -- some nodes in techage have lists that we shouldn't push or pull from
-  no_push("techage:ta4_recipeblock",     "input")
-  no_push("techage:ta4_pusher_pas",      "main")
-  no_push("techage:ta4_pusher_act",      "main")
-  no_push("techage:ta5_hl_chest",        "main")
-  no_push("techage:ta3_doorcontroller2", "main")
-  no_push("techage:ta4_movecontroller2", "main")
-
-  no_pull("techage:ta2_autocrafter_pas", "output")
-  no_pull("techage:ta2_autocrafter_act", "output")
-  no_pull("techage:ta3_autocrafter_pas", "output")
-  no_pull("techage:ta3_autocrafter_act", "output")
-  no_pull("techage:ta4_autocrafter_pas", "output")
-  no_pull("techage:ta4_autocrafter_act", "output")
-  no_pull("techage:ta4_recipeblock",     "output")
-  no_pull("techage:ta4_pusher_pas",      "main")
-  no_pull("techage:ta4_pusher_act",      "main")
-  no_pull("techage:ta5_hl_chest",        "main")
-  no_pull("techage:ta3_doorcontroller2", "main")
-  no_pull("techage:ta4_movecontroller2", "main")
 else
   itemstrings.nodebreaker = L("silverin_circuit")
   itemstrings.cobgen_upgr_additional = ""

--- a/util/disallowed_lists.lua
+++ b/util/disallowed_lists.lua
@@ -1,0 +1,35 @@
+local no_push = logistica.add_disallowed_push_list
+local no_pull = logistica.add_disallowed_pull_list
+
+if minetest.get_modpath("techage") then
+  -- some nodes in techage have lists that we shouldn't push or pull from
+  no_push("techage:ta4_recipeblock",         "input")
+  no_push("techage:ta3_digtron_battery_pas", "fuel")
+  no_push("techage:ta3_digtron_battery_act", "fuel")
+  no_push("techage:ta4_pusher_pas",          "main")
+  no_push("techage:ta4_pusher_act",          "main")
+  no_push("techage:ta5_hl_chest",            "main")
+  no_push("techage:ta3_doorcontroller2",     "main")
+  no_push("techage:ta4_movecontroller2",     "main")
+
+  no_pull("techage:ta2_autocrafter_pas", "output")
+  no_pull("techage:ta2_autocrafter_act", "output")
+  no_pull("techage:ta3_autocrafter_pas", "output")
+  no_pull("techage:ta3_autocrafter_act", "output")
+  no_pull("techage:ta4_autocrafter_pas", "output")
+  no_pull("techage:ta4_autocrafter_act", "output")
+  no_pull("techage:ta4_recipeblock",     "output")
+  no_pull("techage:ta4_pusher_pas",      "main")
+  no_pull("techage:ta4_pusher_act",      "main")
+  no_pull("techage:ta5_hl_chest",        "main")
+  no_pull("techage:ta3_doorcontroller2", "main")
+  no_pull("techage:ta4_movecontroller2", "main")
+end
+
+if minetest.get_modpath("digtron") then
+  no_push("digtron:builder",        "main")
+  no_push("digtron:master_builder", "main")
+
+  no_pull("digtron:builder",        "main")
+  no_pull("digtron:master_builder", "main")
+end

--- a/util/util.lua
+++ b/util/util.lua
@@ -15,6 +15,7 @@ dofile(path.."/inv_list_sorting.lua")
 dofile(path.."/inv_list_filtering.lua")
 dofile(path.."/inv_common.lua")
 dofile(path.."/compat_bucket.lua")
+dofile(path.."/disallowed_lists.lua")
 
 -- bad debug
 local d = {}


### PR DESCRIPTION
Related to issue #34 and PR #39

This PR disallows invlists from Digtron mod:
- `digtron:builder`, `main`
- `digtron:master_builder`, `main`
- `techage:ta3_digtron_battery_pas`, `fuel`
- `techage:ta3_digtron_battery_act`, `fuel`