### PR TITLE
Issue 51 making glass in lava furnace does not work

### DIFF
--- a/api/lava_furnace_recipe.lua
+++ b/api/lava_furnace_recipe.lua
@@ -45,18 +45,20 @@ function logistica.get_lava_furnace_recipes_for(itemName)
 
   if output.time > 0 and decrOut.items[1]:is_empty() then
     local lavaTime = math.max(MIN_TIME, output.time / NORMAL_COOK_REDUCTION_FACTOR)
-    table.insert(presets, {
+    local regularRecipe = {
       input_count = 1,
       output = output.item:to_string(),
       lava = lavaTime * NORMAL_COOK_LAVA_USAGE_PER_SEC,
       time = lavaTime
-    })
+    }
+
+    if presets then table.insert(presets, regularRecipe)
+    else presets = {regularRecipe}
+    end
   end
 
-  if presets then return presets end
-
-  -- nothing found
-  return nil
+  -- returns nil for no matching recipes
+  return presets
 end
 
 -- returns a copy_pointed_thing of internal the internal recipes - for reference

--- a/api/lava_furnace_recipe.lua
+++ b/api/lava_furnace_recipe.lua
@@ -37,22 +37,23 @@ end
 
 function logistica.get_lava_furnace_recipes_for(itemName)
   local presets = lava_furnace_recipes[itemName]
-  if presets then return presets end
 
-  -- else, try to adopt the real one
+  -- also look for regular furnace recipe
   local output, decrOut = minetest.get_craft_result({
     method = "cooking", width = 1, items = { ItemStack(itemName) }
   })
 
   if output.time > 0 and decrOut.items[1]:is_empty() then
     local lavaTime = math.max(MIN_TIME, output.time / NORMAL_COOK_REDUCTION_FACTOR)
-    return {{
+    table.insert(presets, {
       input_count = 1,
       output = output.item:to_string(),
       lava = lavaTime * NORMAL_COOK_LAVA_USAGE_PER_SEC,
       time = lavaTime
-    }}
+    })
   end
+
+  if presets then return presets end
 
   -- nothing found
   return nil

--- a/api/lava_furnace_recipe.lua
+++ b/api/lava_furnace_recipe.lua
@@ -1,5 +1,5 @@
 
-local lava_furance_recipes = {}
+local lava_furnace_recipes = {}
 local NORMAL_COOK_LAVA_USAGE_PER_SEC = 2 -- in millibuckets
 local NORMAL_COOK_REDUCTION_FACTOR = 2
 local MIN_TIME = 0.5
@@ -23,8 +23,8 @@ function logistica.register_lava_furnace_recipe(def)
   end
 
   local useChance = (def.additive_use_chance ~= nil and logistica.clamp(def.additive_use_chance, 0, 100)) or 100
-  lava_furance_recipes[def.input] = lava_furance_recipes[def.input] or {}
-  table.insert(lava_furance_recipes[def.input], {
+  lava_furnace_recipes[def.input] = lava_furnace_recipes[def.input] or {}
+  table.insert(lava_furnace_recipes[def.input], {
     input = def.input,
     input_count = def.input_count or 1,
     output = def.output,
@@ -36,7 +36,7 @@ function logistica.register_lava_furnace_recipe(def)
 end
 
 function logistica.get_lava_furnace_recipes_for(itemName)
-  local presets = lava_furance_recipes[itemName]
+  local presets = lava_furnace_recipes[itemName]
   if presets then return presets end
 
   -- else, try to adopt the real one
@@ -60,5 +60,5 @@ end
 
 -- returns a copy_pointed_thing of internal the internal recipes - for reference
 function logistica.get_lava_furnace_internal_recipes()
-  return table.copy(lava_furance_recipes)
+  return table.copy(lava_furnace_recipes)
 end


### PR DESCRIPTION
Before, when there is a lava furnace recipe for a specific item, it would never consider the regular furnace recipe.
With this change, **all** recipes are considered for a specific item in the lava furnace.