### PR TITLE
Feature: Mesecons/Redstone-capable Toggleable Cables

### DIFF
--- a/api/cables_toggleable.lua
+++ b/api/cables_toggleable.lua
@@ -6,8 +6,8 @@ local function ends_with(str, ending)
   return str:sub(-#ending) == ending
 end
 
-local function toggle_cable(pos, node, clicker, itemstack, pointed_thing)
-  if clicker:is_player() and minetest.is_protected(pos, clicker:get_player_name()) then return end
+-- General purpose cable toggle, used for mesecons and player action..
+local function toggle_cable(pos, node)
   local nodeName = node.name
   if ends_with(nodeName, "_on") then
     nodeName = nodeName:sub(1, #nodeName - 3).."_off"
@@ -20,13 +20,24 @@ local function toggle_cable(pos, node, clicker, itemstack, pointed_thing)
   end
 end
 
--- Main function to register a new toggleable cable
-function logistica.register_cable_toggleable(desc, name, tilesOn, tilesOff)
+-- Specific case when a player toggles a cable. Usable in on_rightclick, and checks for protection.
+local function toggle_cable_player(pos, node, clicker, itemstack, pointed_thing)
+  if clicker:is_player() and minetest.is_protected(pos, clicker:get_player_name()) then return end
+  toggle_cable(pos, node)
+end
+
+
+-- Main function to register a new toggleable cable.
+--
+-- Final parameters dictate whether:
+-- - the player can toggle the cable
+-- - the cable can be controlled by mesecons (if mesecons is not available then it will not register - if creating 
+--   a separate triplet of nodes for mesecons control, consider not registering mesecons-only nodes). 
+function logistica.register_cable_toggleable(desc, name, tilesOn, tilesOff, enableRightClickToggle, enableMeseconsControl)
   local lname = string.lower(name)
   local nameOff = "logistica:"..lname.."_off"
 
   for _, state in ipairs({"on", "off"}) do
-
     local node_box = {
       type           = "connected",
       fixed          = { -0.25, -0.25, -0.25, 0.25, 0.25, 0.25},
@@ -73,18 +84,41 @@ function logistica.register_cable_toggleable(desc, name, tilesOn, tilesOff)
       connects_to = connectsTo,
       on_construct = onConst,
       after_dig_node = afterDig,
-      on_rightclick = toggle_cable,
+      on_rightclick = toggle_cable_player,
       _mcl_hardness = 1.5,
       _mcl_blast_resistance = 10
     }
+
+    if enableRightClickToggle then
+      def.on_rightclick = toggle_cable_player
+    end
+
 
     if state == "on" then
       logistica.GROUPS.cables.register(cable_name)
       def.groups[logistica.TIER_ALL] = 1
       def.groups.not_in_creative_inventory = 1
+      -- If on, then we only want to act when the mesecons turns off from an on state.
+      -- until next by player action.
+      if logistica.mesecons_is_present() and enableMeseconsControl then
+        def.mesecons = {
+          effector = {
+            action_off = toggle_cable
+          }
+        }
+      end
     else
       def.node_box = { type = "fixed", fixed = { -0.25, -0.25, -0.25, 0.25, 0.25, 0.25} }
       def.groups[logistica.TIER_CABLE_OFF] = 1
+
+      -- If on, then we only want to act when the mesecons turns on from an off state.
+      if logistica.mesecons_is_present() and enableMeseconsControl then
+        def.mesecons = {
+          effector = {
+            action_on = toggle_cable
+          }
+        }
+      end
     end
 
     minetest.register_node(cable_name, def)

--- a/guide/guide_desc_machines.lua
+++ b/guide/guide_desc_machines.lua
@@ -65,7 +65,9 @@ Placing a cable that bridges two different active networks will burn that cable.
 Note that Cables are the only way to extend a network's reach - meaning, machines will not carry the network connection through them. If you connect a network cable to one side of a machine, and then place a 2nd cable on the other side of the machine, the 2nd cable will not carry the network connection.
 
 # Toggleable Cables
-The Toggleable Cable works exactly like a regular cable, but can be right-clicked (aka used) to disconnect it from all other surrounding cables or machines. This allows you to make parts of your network easy to disconnect when you don't want to use them (For example, a disconnecting an auto-furnace setup when you don't need it anymore)
+The Toggleable Cable works exactly like a regular cable, but can be right-clicked (aka used) to disconnect it from all other surrounding cables or machines. This allows you to make parts of your network easy to disconnect when you don't want to use them (For example, a disconnecting an auto-furnace setup when you don't need it anymore).
+
+Toggleable Cables can also be controlled with mesecons or redstone (depending on what game base you are running). When right-clicked while being controlled by mesecons/redstone, the change will persist until the circuit undergoes a power cycle. (For example, if the mesecon was off, and a player right-clicked the Toggleable Cable to turn it on, then the mesecon would have to turn on and then off again to disable the Toggleable Cable once more).
 
 #Embedded Cables
 The Embedded Cable is a full block that acts like a regular Optic Cable, allowing cables to be run through walls without leaving visible gaps.

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = logistica
-optional_depends = default, bucket, i3, mcl_core, mcl_buckets, mcl_nether, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, bucket_wooden, techage
+optional_depends = default, bucket, i3, mcl_core, mcl_buckets, mcl_nether, unified_inventory, mcl_mobitems, animalia, ethereal, mesecons_mvps, mesecons, bucket_wooden, techage
 min_minetest_version = 5.4.0
 author = ZenonSeth
 description = On-demand Item Transportation + Powerful Item and Liquid Storage

--- a/registration/machines_api_reg.lua
+++ b/registration/machines_api_reg.lua
@@ -71,7 +71,9 @@ logistica.register_cable(S("Embedded Optic Cable"), "optic_cable_block",
 -- toggleable
 logistica.register_cable_toggleable(S("Toggleable Cable"), "optic_cable_toggleable",
   {"logistica_cable_toggleable_on.png"},
-  {"logistica_cable_toggleable_off.png"}
+  {"logistica_cable_toggleable_off.png"},
+  true,
+  true
 )
 
 --------------------------------

--- a/util/compat_mesecons.lua
+++ b/util/compat_mesecons.lua
@@ -1,9 +1,14 @@
-
 local mesecon_pushers = minetest.get_modpath("mesecons_mvps")
+local mesecons_is_present = minetest.get_modpath("mesecons")
 
 local register_stopper = function(name, func) end
 if mesecon_pushers then register_stopper = mesecon.register_mvps_stopper end
 
 function logistica.register_non_pushable(nodeName)
   register_stopper(nodeName)
+end
+
+-- Mesecons apis are present.
+function logistica.mesecons_is_present()
+  return mesecons_is_present
 end


### PR DESCRIPTION
Implements & documents mesecons control of the toggleable cables. Doesn't have massive amounts of use right this second, but combined with possible future mesecons and digilines mechanisms[^1], this would enable very high levels of demand-based automation and/or luacontroller analysis type stuff nya ^.^

The changes I made can also be trivially adjusted to make separate mesecons-controlled and player-controlled cables with the function parameters, if desired. It'd just need textures, a crafting recipe, and a second call of the toggleable cable function.

[^1]: I may implement these but won't commit to doing so because that means I will definitely end up not doing it lol. 