### PR TITLE
Fixing Network Rescan signal issues and insulated cables

### DIFF
--- a/api/cable_insulating.lua
+++ b/api/cable_insulating.lua
@@ -2,7 +2,7 @@ local S = logistica.TRANSLATOR
 local SIZE = logistica.settings.cable_size
 
 -- shape = "straight" (default, group value 1): connects front-to-back only.
--- shape = "l_shape"  (group value 2): connects front arm (z-) and right arm (x+).
+-- shape = "l_shape"  (group value 2): connects front arm (z-) and left arm (x+) at default rotation.
 -- Network scan enforces the direction; all other faces are insulated.
 function logistica.register_insulating_cable(desc, name, customTiles, shape)
   local lname = string.lower(name)
@@ -51,6 +51,26 @@ function logistica.register_insulating_cable(desc, name, customTiles, shape)
     node_box = node_box,
     on_construct = function(pos) logistica.on_cable_insulating_change(pos) end,
     after_dig_node = function(pos, oldnode, oldmeta, _) logistica.on_cable_insulating_change(pos, oldnode, oldmeta) end,
+    on_punch = function(pos, node, player, _)
+      if not player or not player:is_player() then return end
+      if not player:get_player_control().sneak then return end
+      local d = logistica.get_rot_directions(node.param2)
+      if not d then return end
+      local key = tostring(minetest.hash_node_position(pos))
+      if isL then
+        logistica.show_input_at(vector.add(pos, d.forward), key .. "a")
+        logistica.show_input_at(vector.add(pos, d.left),    key .. "b")
+      else
+        logistica.show_input_at(vector.add(pos, d.forward),  key .. "a")
+        logistica.show_input_at(vector.add(pos, d.backward), key .. "b")
+      end
+    end,
+    on_rotate = function(pos, node, _player, _mode, newParam2)
+      node.param2 = newParam2
+      minetest.set_node(pos, node)
+      logistica.rescan_network_at_pos(pos)
+      return true
+    end,
     _mcl_hardness = 1.5,
     _mcl_blast_resistance = 10,
   }

--- a/logic/network_logic.lua
+++ b/logic/network_logic.lua
@@ -307,13 +307,13 @@ end
 
 -- Can the cable propagate the scan OUT in this offset direction?
 -- Type 1 (straight): forward or backward axis only.
--- Type 2 (L-shape): forward or right only.
+-- Type 2 (L-shape): forward or left only (nodebox arms go -Z and +X at facedir=0).
 local function insul_allows_exit(offset, d, insulType)
   if not d then return true end
   if insulType == 1 then
     return vec_eq(offset, d.forward) or vec_eq(offset, d.backward)
   elseif insulType == 2 then
-    return vec_eq(offset, d.forward) or vec_eq(offset, d.right)
+    return vec_eq(offset, d.forward) or vec_eq(offset, d.left)
   end
   return true
 end
@@ -321,13 +321,13 @@ end
 -- Can the scan enter the cable FROM this offset direction?
 -- Entry direction is the negative of the arm direction (approaching from outside the arm end).
 -- Type 1 (straight): same as exit (symmetric).
--- Type 2 (L-shape): backward or left (the negative of forward/right).
+-- Type 2 (L-shape): backward or right (the negative of forward/left).
 local function insul_allows_entry(offset, d, insulType)
   if not d then return true end
   if insulType == 1 then
     return vec_eq(offset, d.forward) or vec_eq(offset, d.backward)
   elseif insulType == 2 then
-    return vec_eq(offset, d.backward) or vec_eq(offset, d.left)
+    return vec_eq(offset, d.backward) or vec_eq(offset, d.right)
   end
   return true
 end

--- a/logic/network_logic.lua
+++ b/logic/network_logic.lua
@@ -127,9 +127,14 @@ function logistica.get_network_id_or_nil(pos)
   if not network then return nil else return network.controller end
 end
 
+-- Set by rescan_network to suppress on_connect_to_network for nodes that were
+-- already on the network before the rescan. Their state has not changed.
+local rescan_skip_notify = nil
+
 local function notify_connected(pos, nodeName, networkId)
   -- set the cached network ID first
   set_cache_network_id(minetest.get_meta(pos), networkId)
+  if rescan_skip_notify and rescan_skip_notify[p2h(pos)] then return end
   local def = minetest.registered_nodes[nodeName]
   if def and def.logistica and def.logistica.on_connect_to_network then
     def.logistica.on_connect_to_network(pos, networkId)
@@ -434,7 +439,10 @@ local function update_all_network_caches(network)
   logistica.update_cache_network(network, LOG_CACHE_SUPPLIER)
 end
 
-local function create_network(controllerPosition, oldNetworkName)
+-- initialSignals: optional {name -> {hash -> true}} copied from previous network so that
+-- on_connect_to_network callbacks that call signal_get_state see the right state.
+-- Stale sender entries are cleaned up via notify_disconnected -> signal_remove_sender.
+local function create_network(controllerPosition, oldNetworkName, initialSignals)
   local node = minetest.get_node(controllerPosition)
   if not node.name:find("_controller") or not node.name:find("logistica:") then return false end
   local meta = minetest.get_meta(controllerPosition)
@@ -456,6 +464,13 @@ local function create_network(controllerPosition, oldNetworkName)
   network.supplier_cache = {}
   network.requester_cache = {}
   network.signals = {}  -- {signal_name -> {sender_hash -> true}} for all active ON senders
+  if initialSignals then
+    for name, senders in pairs(initialSignals) do
+      local copy = {}
+      for senderHash, _ in pairs(senders) do copy[senderHash] = true end
+      if not logistica.table_is_empty(copy) then network.signals[name] = copy end
+    end
+  end
   network._num_nodes = 0
 
   local startPos = { [controllerHash] = true }
@@ -489,8 +504,11 @@ local function rescan_network(networkId)
   local controllerPosition = h2p(conHash)
   local oldNetworkName = network.name
   local oldHashes = collect_network_hashes(network)
+  local oldSignals = network.signals
   clear_network(networkId, true)
-  create_network(controllerPosition, oldNetworkName)
+  rescan_skip_notify = oldHashes
+  create_network(controllerPosition, oldNetworkName, oldSignals)
+  rescan_skip_notify = nil
   local newNetwork = networks[conHash]
   for hash, _ in pairs(oldHashes) do
     if not newNetwork or not network_contains_hash(newNetwork, hash) then
@@ -967,12 +985,15 @@ end
 -- Send a named signal ON or OFF from pos. Notifies all receivers on the network.
 -- Uses OR semantics: signal is ON as long as any sender has it ON.
 -- Gate receivers are processed breadth-first to prevent unbounded recursion.
+-- Receivers are only notified when the aggregate signal state actually changes,
+-- preventing flip-flop gates from toggling on every poll of a persistent sender.
 function logistica.signal_send(pos, name, isOn)
   if not name or name == "" then return end
   local network = logistica.get_network_or_nil(pos)
   if not network then return end
   local hash = p2h(pos)
   if not network.signals[name] then network.signals[name] = {} end
+  local prevIsOn = not logistica.table_is_empty(network.signals[name])
   if isOn then
     network.signals[name][hash] = true
   else
@@ -982,6 +1003,7 @@ function logistica.signal_send(pos, name, isOn)
     end
   end
   local signalIsOn = network.signals[name] ~= nil
+  if signalIsOn == prevIsOn then return end
   if network._propagation then
     notify_signal_receivers(network, name, signalIsOn)
     return

--- a/logic/signal_toggle.lua
+++ b/logic/signal_toggle.lua
@@ -1,7 +1,8 @@
 
-local META_INPUT  = "toggle_input"
-local META_OUTPUT = "toggle_output"
-local META_STATE  = "toggle_state"
+local META_INPUT      = "toggle_input"
+local META_OUTPUT     = "toggle_output"
+local META_STATE      = "toggle_state"
+local META_LAST_INPUT = "toggle_last_input"
 
 local DEFAULT_INPUT  = ""
 local DEFAULT_OUTPUT = "signal_out"
@@ -49,8 +50,12 @@ end
 
 -- Returns true if the signal matched and was processed, false otherwise.
 function logistica.signal_toggle_on_signal_received(pos, sigName, sigIsOn)
-  if not sigIsOn then return false end -- only rising edge triggers a toggle
   if sigName ~= logistica.signal_toggle_get_input(pos) then return false end
+  local meta = minetest.get_meta(pos)
+  local lastInput = meta:get_int(META_LAST_INPUT) == 1
+  meta:set_int(META_LAST_INPUT, sigIsOn and 1 or 0)
+  if not sigIsOn then return false end  -- falling edge: update stored state, no flip
+  if lastInput then return false end    -- was already ON: not a rising edge, no flip
   local newState = not logistica.signal_toggle_get_state(pos)
   set_state(pos, newState)
   set_visual(pos, newState)
@@ -77,6 +82,7 @@ function logistica.signal_toggle_on_disconnect(pos, networkId)
   logistica.signal_remove_sender(pos, networkId)
   set_visual(pos, false)
   update_infotext(pos, false)
+  minetest.get_meta(pos):set_int(META_LAST_INPUT, 0)
 end
 
 -- Manually flip the output state and broadcast it on the network.


### PR DESCRIPTION
- Fix issue happening due to Network Switch re-scanning network and signals being re-sent incorrectly https://github.com/ZenonSeth/logistica/issues/73
- Handle on_rotate for insulted cables (I and L) https://github.com/ZenonSeth/logistica/issues/74
- Fix L cable direction to reflect visuals
- Add extra logic to Network Toggle to avoid toggling on server startup
