### PR TITLE
Version 2.0.6

### DIFF
--- a/logic/network_logic.lua
+++ b/logic/network_logic.lua
@@ -280,10 +280,21 @@ end
 -- returns a numberOfNetworks (which is 0, 1, 2), networkOrNil
 local function find_adjacent_networks(pos)
   local currNetwork = nil
+  local selfIsToggler = logistica.GROUPS.signal_togglers.is(minetest.get_node(pos).name)
   for _, adj in pairs(adjacent) do
     local otherPos = vector.add(pos, adj)
-    local otherNodeName = minetest.get_node(otherPos).name
-    if logistica.GROUPS.cables.is(otherNodeName) or logistica.GROUPS.controllers.is(otherNodeName) then
+    local otherNode = minetest.get_node(otherPos)
+    local otherNodeName = otherNode.name
+    -- an ON signal toggler relays the network to whatever it's facing, same as the full network scan does
+    local isActiveTogglerRelay = logistica.GROUPS.signal_togglers.is(otherNodeName) and ends_with(otherNodeName, ON_SUFFIX)
+    if isActiveTogglerRelay and selfIsToggler then
+      -- mirror the scan's one-way gate: block another toggler from entering via the backward (output) face
+      local d = logistica.get_rot_directions(otherNode.param2)
+      if d and adj.x == d.forward.x and adj.y == d.forward.y and adj.z == d.forward.z then
+        isActiveTogglerRelay = false
+      end
+    end
+    if logistica.GROUPS.cables.is(otherNodeName) or logistica.GROUPS.controllers.is(otherNodeName) or isActiveTogglerRelay then
       local otherNetwork = logistica.get_network_or_nil(otherPos)
       if otherNetwork ~= nil then
         if currNetwork == nil then currNetwork = otherNetwork

--- a/logic/network_logic.lua
+++ b/logic/network_logic.lua
@@ -277,36 +277,6 @@ local function break_logistica_node(pos)
   end
 end
 
--- returns a numberOfNetworks (which is 0, 1, 2), networkOrNil
-local function find_adjacent_networks(pos)
-  local currNetwork = nil
-  local selfIsToggler = logistica.GROUPS.signal_togglers.is(minetest.get_node(pos).name)
-  for _, adj in pairs(adjacent) do
-    local otherPos = vector.add(pos, adj)
-    local otherNode = minetest.get_node(otherPos)
-    local otherNodeName = otherNode.name
-    -- an ON signal toggler relays the network to whatever it's facing, same as the full network scan does
-    local isActiveTogglerRelay = logistica.GROUPS.signal_togglers.is(otherNodeName) and ends_with(otherNodeName, ON_SUFFIX)
-    if isActiveTogglerRelay and selfIsToggler then
-      -- mirror the scan's one-way gate: block another toggler from entering via the backward (output) face
-      local d = logistica.get_rot_directions(otherNode.param2)
-      if d and adj.x == d.forward.x and adj.y == d.forward.y and adj.z == d.forward.z then
-        isActiveTogglerRelay = false
-      end
-    end
-    if logistica.GROUPS.cables.is(otherNodeName) or logistica.GROUPS.controllers.is(otherNodeName) or isActiveTogglerRelay then
-      local otherNetwork = logistica.get_network_or_nil(otherPos)
-      if otherNetwork ~= nil then
-        if currNetwork == nil then currNetwork = otherNetwork
-        elseif currNetwork ~= otherNetwork then return 2, nil end
-      end
-    end
-  end
-  local numNetworks = 1
-  if currNetwork == nil then numNetworks = 0 end
-  return numNetworks, currNetwork
-end
-
 -- Returns 1 for straight insulating cable, 2 for L-shape, 0 for not insulating.
 local function get_insul_type(nodeName)
   return minetest.get_item_group(nodeName, "logistica_insulating")
@@ -341,6 +311,44 @@ local function insul_allows_entry(offset, d, insulType)
     return vec_eq(offset, d.backward) or vec_eq(offset, d.right)
   end
   return true
+end
+
+-- returns a numberOfNetworks (which is 0, 1, 2), networkOrNil
+local function find_adjacent_networks(pos)
+  local currNetwork = nil
+  local selfIsToggler = logistica.GROUPS.signal_togglers.is(minetest.get_node(pos).name)
+  for _, adj in pairs(adjacent) do
+    local otherPos = vector.add(pos, adj)
+    local otherNode = minetest.get_node(otherPos)
+    local otherNodeName = otherNode.name
+    local isCable = logistica.GROUPS.cables.is(otherNodeName)
+    if isCable then
+      -- block connecting through an insulating cable on a non-permitted face, same as the full network scan does
+      local insulType = get_insul_type(otherNodeName)
+      if insulType > 0 and not insul_allows_entry(adj, logistica.get_rot_directions(otherNode.param2), insulType) then
+        isCable = false
+      end
+    end
+    -- an ON signal toggler relays the network to whatever it's facing, same as the full network scan does
+    local isActiveTogglerRelay = logistica.GROUPS.signal_togglers.is(otherNodeName) and ends_with(otherNodeName, ON_SUFFIX)
+    if isActiveTogglerRelay and selfIsToggler then
+      -- mirror the scan's one-way gate: block another toggler from entering via the backward (output) face
+      local d = logistica.get_rot_directions(otherNode.param2)
+      if d and vec_eq(adj, d.forward) then
+        isActiveTogglerRelay = false
+      end
+    end
+    if isCable or logistica.GROUPS.controllers.is(otherNodeName) or isActiveTogglerRelay then
+      local otherNetwork = logistica.get_network_or_nil(otherPos)
+      if otherNetwork ~= nil then
+        if currNetwork == nil then currNetwork = otherNetwork
+        elseif currNetwork ~= otherNetwork then return 2, nil end
+      end
+    end
+  end
+  local numNetworks = 1
+  if currNetwork == nil then numNetworks = 0 end
+  return numNetworks, currNetwork
 end
 
 local function recursive_scan_for_nodes_for_controller(network, positionHashes, numScanned)

--- a/logic/network_storage.lua
+++ b/logic/network_storage.lua
@@ -168,6 +168,8 @@ function logistica.take_stack_from_suppliers(stackToTake, network, collectorFunc
           logistica.GROUPS.suppliers.is(nodeName)
           or logistica.GROUPS.vaccuum_suppliers.is(nodeName)
           or logistica.GROUPS.bucket_emptiers.is(nodeName)
+          or logistica.GROUPS.wood_suppliers.is(nodeName)
+          or logistica.GROUPS.farming_suppliers.is(nodeName)
       )
     then
       normalSupplierResult = logistica.take_item_from_supplier(pos, takeStack, network, collectorFunc, useMetadata, dryRun)
@@ -465,7 +467,9 @@ function logistica.count_items_in_network(itemName, network, respectReserve)
       logistica.load_position(pos)
       local nodeName = minetest.get_node(pos).name
       if logistica.GROUPS.suppliers.is(nodeName)
-          or logistica.GROUPS.vaccuum_suppliers.is(nodeName) then
+          or logistica.GROUPS.vaccuum_suppliers.is(nodeName)
+          or logistica.GROUPS.wood_suppliers.is(nodeName)
+          or logistica.GROUPS.farming_suppliers.is(nodeName) then
         local list = logistica.get_list(minetest.get_meta(pos):get_inventory(), SUPPLIER_LIST_NAME)
         for _, stack in ipairs(list) do
           if stack:get_name() == itemName then

--- a/logic/network_storage.lua
+++ b/logic/network_storage.lua
@@ -482,3 +482,74 @@ function logistica.count_items_in_network(itemName, network, respectReserve)
 
   return count
 end
+
+-- Same sources/exclusions as count_items_in_network, but stops scanning as soon as
+-- the threshold comparison is decided (count is monotonically increasing during the
+-- scan, so the early-stopped count still satisfies the same comparison as the full
+-- count would).
+local function count_items_until_decided(itemName, network, respectReserve, threshold, stopAbove)
+  if not itemName or itemName == "" then return 0 end
+  local count = 0
+
+  local function should_stop()
+    if stopAbove then return count >= threshold end
+    return count > threshold
+  end
+
+  local massLocations = network.storage_cache[itemName]
+  if massLocations then
+    for hash, _ in pairs(massLocations) do
+      local pos = h2p(hash)
+      logistica.load_position(pos)
+      local meta = minetest.get_meta(pos)
+      local list = logistica.get_list(meta:get_inventory(), MASS_STORAGE_LIST_NAME)
+      for i, stack in ipairs(list) do
+        if stack:get_name() == itemName then
+          local available = stack:get_count()
+          if respectReserve then
+            available = math.max(0, available - logistica.get_mass_storage_reserve(meta, i))
+          end
+          count = count + available
+          if should_stop() then return count end
+        end
+      end
+    end
+  end
+
+  local supplierLocations = network.supplier_cache[itemName]
+  if supplierLocations then
+    for hash, _ in pairs(supplierLocations) do
+      local pos = h2p(hash)
+      logistica.load_position(pos)
+      local nodeName = minetest.get_node(pos).name
+      if logistica.GROUPS.suppliers.is(nodeName)
+          or logistica.GROUPS.vaccuum_suppliers.is(nodeName)
+          or logistica.GROUPS.wood_suppliers.is(nodeName)
+          or logistica.GROUPS.farming_suppliers.is(nodeName) then
+        local list = logistica.get_list(minetest.get_meta(pos):get_inventory(), SUPPLIER_LIST_NAME)
+        for _, stack in ipairs(list) do
+          if stack:get_name() == itemName then
+            count = count + stack:get_count()
+            if should_stop() then return count end
+          end
+        end
+      end
+    end
+  end
+
+  return count
+end
+
+-- True if the network contains at least `threshold` of itemName. Stops scanning
+-- as soon as the threshold is reached.
+function logistica.network_has_at_least(itemName, network, threshold, respectReserve)
+  local count = count_items_until_decided(itemName, network, respectReserve, threshold, true)
+  return count >= threshold
+end
+
+-- True if the network contains at most `threshold` of itemName. Stops scanning
+-- as soon as the count exceeds the threshold.
+function logistica.network_has_at_most(itemName, network, threshold, respectReserve)
+  local count = count_items_until_decided(itemName, network, respectReserve, threshold, false)
+  return count <= threshold
+end

--- a/logic/signal_item_counter.lua
+++ b/logic/signal_item_counter.lua
@@ -80,7 +80,6 @@ local function do_evaluate(pos, networkId)
   local network = logistica.get_network_by_id_or_nil(networkId)
   if not network then return end
   local respectReserve = logistica.signal_item_counter_get_respect_reserve(pos)
-  local count = logistica.count_items_in_network(itemName, network, respectReserve)
   local threshold = logistica.signal_item_counter_get_threshold(pos)
   local comparison = logistica.signal_item_counter_get_comparison(pos)
   local sigName = logistica.signal_item_counter_get_signal_name(pos)
@@ -90,8 +89,12 @@ local function do_evaluate(pos, networkId)
     logistica.signal_item_counter_update_infotext(pos)
     return
   end
-  local conditionMet = (comparison == ">=") and (count >= threshold)
-                    or (comparison == "<=") and (count <= threshold)
+  local conditionMet
+  if comparison == ">=" then
+    conditionMet = logistica.network_has_at_least(itemName, network, threshold, respectReserve)
+  else
+    conditionMet = logistica.network_has_at_most(itemName, network, threshold, respectReserve)
+  end
   logistica.signal_send(pos, sigName, conditionMet)
   set_visual(pos, conditionMet)
   logistica.signal_item_counter_update_infotext(pos)

--- a/registration/machines_api_reg.lua
+++ b/registration/machines_api_reg.lua
@@ -95,14 +95,16 @@ logistica.register_insulating_cable(S("Insulated Optic Cable (L-Shape)"), "cable
 -- Cobble Generator
 --------------------------------
 
-logistica.register_cobble_generator_supplier(S("Cobble Generator"), "cobblegen_supplier", {
-  "logistica_cobblegen_top.png",
-  "logistica_cobblegen_bottom.png",
-  "logistica_cobblegen_side.png^[transformFX",
-  "logistica_cobblegen_side.png",
-  "logistica_cobblegen_back.png",
-  "logistica_cobblegen_front.png",
-})
+if logistica.settings.enable_cobblestone_supplier then
+  logistica.register_cobble_generator_supplier(S("Cobble Generator"), "cobblegen_supplier", {
+    "logistica_cobblegen_top.png",
+    "logistica_cobblegen_bottom.png",
+    "logistica_cobblegen_side.png^[transformFX",
+    "logistica_cobblegen_side.png",
+    "logistica_cobblegen_back.png",
+    "logistica_cobblegen_front.png",
+  })
+end -- enable_cobblestone_supplier
 
 --------------------------------
 -- Controller

--- a/registration/node_recipes.lua
+++ b/registration/node_recipes.lua
@@ -167,18 +167,20 @@ logistica.register_craft({
   }
 })
 
-logistica.register_craft({
-  output = L("cobblegen_supplier"),
-  recipe = {
-    {L("silverin_plate"), itemstrings.lava_bucket,  L("silverin_plate")},
-    {L("optic_cable"),    L("photonizer"),          itemstrings.nodebreaker},
-    {L("silverin_plate"), itemstrings.water_bucket, L("silverin_plate")},
-  },
-  replacements = {
-    {itemstrings.water_bucket, itemstrings.empty_bucket},
-    {itemstrings.lava_bucket,  itemstrings.empty_bucket},
-  }
-})
+if logistica.settings.enable_cobblestone_supplier then
+  logistica.register_craft({
+    output = L("cobblegen_supplier"),
+    recipe = {
+      {L("silverin_plate"), itemstrings.lava_bucket,  L("silverin_plate")},
+      {L("optic_cable"),    L("photonizer"),          itemstrings.nodebreaker},
+      {L("silverin_plate"), itemstrings.water_bucket, L("silverin_plate")},
+    },
+    replacements = {
+      {itemstrings.water_bucket, itemstrings.empty_bucket},
+      {itemstrings.lava_bucket,  itemstrings.empty_bucket},
+    }
+  })
+end -- enable_cobblestone_supplier
 
 if logistica.settings.enable_wireless_access_pad then
   logistica.register_craft({

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -14,6 +14,7 @@ logistica_enable_digiline_machines (Enable the Digiline Signal Sender and Digili
 logistica_enable_digiline_sender_api (Enable the Digiline Sender API programming feature) bool true
 logistica_enable_node_digger (Enable the Signal Node Digger) bool true
 logistica_enable_node_placer (Enable the Signal Node Placer) bool true
+logistica_enable_cobblestone_supplier (Enable the Cobble Generator Supplier) bool true
 logistica_node_detector_max_distance (Max distance the Signal Node Detector can reach) int 16 1 32
 logistica_node_digger_max_distance (Max distance the Signal Node Digger can reach) int 16 1 32
 logistica_node_placer_max_distance (Max distance the Signal Node Placer can reach) int 16 1 32

--- a/util/settings.lua
+++ b/util/settings.lua
@@ -58,6 +58,8 @@ logistica.settings.enable_node_digger = get_bool("enable_node_digger", true)
 
 logistica.settings.enable_node_placer = get_bool("enable_node_placer", true)
 
+logistica.settings.enable_cobblestone_supplier = get_bool("enable_cobblestone_supplier", true)
+
 logistica.settings.node_detector_max_distance = get_int("node_detector_max_distance", 16, 1, 32)
 
 logistica.settings.node_digger_max_distance = get_int("node_digger_max_distance", 16, 1, 32)


### PR DESCRIPTION
- Add setting to disable cobblestone generator (requested in https://github.com/ZenonSeth/logistica/issues/56)
- Fix woodcutter and farming supplier not being entirely correctly accessible from network (https://github.com/ZenonSeth/logistica/issues/78)
- Fix placing any machine after a Network Switch not connecting correctly (https://github.com/ZenonSeth/logistica/issues/77)
- Fix placing any machine after an insulated cable not accounting for the cable's input/output directions
- Add optimization for item count comparisons so they don't have to scan entire network content if there's more items in network than their target amount.