### PR TITLE
Version 2.0.9

### DIFF
--- a/api/reservoir.lua
+++ b/api/reservoir.lua
@@ -7,6 +7,8 @@ local EMPTY_SUFFIX = "_empty"
 
 local LIQUID_NONE = ""
 
+local LAVA_UNIT_ITEM = "logistica:lava_unit"
+
 local VAR_SMALL = "silverin"
 local VAR_LARGE = "obsidian"
 
@@ -114,6 +116,12 @@ end
 local function on_rightclick(pos, node, player, itemstack, pointed_thing, max)
   if not player or not player:is_player() or not logistica.player_has_network_access(pos, player:get_player_name()) then return end
 
+    if itemstack:get_name() == LAVA_UNIT_ITEM then
+      if not logistica.reservoir_deposit_lava_unit(pos, node) then return end
+      itemstack:take_item(1)
+      return itemstack
+    end
+
     local usedItem = logistica.reservoir_use_item_on(pos, itemstack, node)
 
     if not usedItem then return end
@@ -125,6 +133,18 @@ local function on_rightclick(pos, node, player, itemstack, pointed_thing, max)
       itemstack:take_item(1)
       return itemstack
     end
+end
+
+local function on_punch(pos, node, puncher, pointed_thing)
+  if not puncher or not puncher:is_player() then return end
+  if not logistica.player_has_network_access(pos, puncher:get_player_name()) then return end
+
+  local wielded = puncher:get_wielded_item()
+  if wielded:get_name() ~= LAVA_UNIT_ITEM then return end
+  if not logistica.reservoir_deposit_lava_unit(pos, node) then return end
+
+  wielded:take_item(1)
+  puncher:set_wielded_item(wielded)
 end
 
 --------------------------------
@@ -142,6 +162,7 @@ local commonDef = {
   after_place_node = after_place_node,
   after_dig_node = logistica.on_reservoir_change,
   on_rightclick = on_rightclick,
+  on_punch = on_punch,
   stack_max = 1,
   backface_culling = false,
   _mcl_hardness = 1.5,

--- a/api/supplier.lua
+++ b/api/supplier.lua
@@ -3,12 +3,19 @@ local FS = logistica.FTRANSLATOR
 local FORMSPEC_NAME = "logistica_supplier"
 local BTN_ALLOW_MACHINES = "allow_machines_btn"
 local BTN_ALLOW_AP       = "allow_ap_btn"
+local BTN_PAGE           = "page_btn"
 local META_ALLOW_MACHINES = "supplier_allow_machines"
 local META_ALLOW_AP       = "supplier_allow_ap"
 local FILTER_LIST = "filter"
 local NUM_FILTER_SLOTS = 8
+local MAIN_LIST_PAGE_SIZE = 32 -- 8x4 slots shown at a time
 
 local supplierForms = {}
+
+local function get_supplier_total_pages(pos)
+  local size = logistica.get_supplier_inv_size(pos)
+  return math.max(1, math.ceil(size / MAIN_LIST_PAGE_SIZE))
+end
 
 local function supplier_has_filter(pos)
   local inv = minetest.get_meta(pos):get_inventory()
@@ -20,12 +27,23 @@ local function supplier_has_filter(pos)
   return false
 end
 
-local function get_supplier_formspec(pos)
+local function get_supplier_formspec(pos, page)
   local posForm = "nodemeta:"..pos.x..","..pos.y..","..pos.z
   local meta = minetest.get_meta(pos)
   local allowMachines = meta:get_string(META_ALLOW_MACHINES) ~= "0"
   local allowAp       = meta:get_string(META_ALLOW_AP) ~= "0"
   local hasFilter = supplier_has_filter(pos)
+
+  local totalPages = get_supplier_total_pages(pos)
+  page = math.min(math.max(page or 1, 1), totalPages)
+  local startIndex = (page - 1) * MAIN_LIST_PAGE_SIZE
+
+  local pageBtn = ""
+  if totalPages > 1 then
+    pageBtn = "button[8.4,0.3;1.8,0.75;"..BTN_PAGE..";"..
+      FS("Page ")..page..FS(" of ")..totalPages.."]"..
+      "tooltip["..BTN_PAGE..";"..FS("Click to view the next page of this chest's inventory").."]"
+  end
 
   local depositBtn = ""
   if hasFilter then
@@ -38,7 +56,8 @@ local function get_supplier_formspec(pos)
     logistica.ui.background..
     logistica.ui.button_only_style..
     "label[0.6,0.4;"..FS("Passive Supplier\nItems become available to network requests.").."]"..
-    "list["..posForm..";main;0.4,1.3;8,4;0]"..
+    pageBtn..
+    "list["..posForm..";main;0.4,1.3;8,4;"..startIndex.."]"..
     "label[0.4,6.3;"..FS("Items allowed to be stored (if empty, then all accepted):").."]"..
     "list["..posForm..";filter;0.4,6.5;8,1;0]"..
     logistica.ui.on_off_btn(allowMachines, 0.4,  7.85, BTN_ALLOW_MACHINES, FS("Allow Storing from Machines"))..
@@ -49,8 +68,11 @@ local function get_supplier_formspec(pos)
     "listring["..posForm..";main]"
 end
 
-local function show_supplier_formspec(playerName, pos)
-  supplierForms[playerName] = {position = pos}
+local function show_supplier_formspec(playerName, pos, page)
+  if not page then
+    page = supplierForms[playerName] and supplierForms[playerName].page or 1
+  end
+  supplierForms[playerName] = {position = pos, page = page}
   local meta = minetest.get_meta(pos)
   -- resize inventory for existing chests placed before the size increase
   local inv = meta:get_inventory()
@@ -64,7 +86,7 @@ local function show_supplier_formspec(playerName, pos)
   if logistica.is_machine_on(pos) then
     logistica.toggle_machine_on_off(pos)
   end
-  minetest.show_formspec(playerName, FORMSPEC_NAME, get_supplier_formspec(pos))
+  minetest.show_formspec(playerName, FORMSPEC_NAME, get_supplier_formspec(pos, page))
 end
 
 local function on_player_receive_fields(player, formname, fields)
@@ -90,6 +112,10 @@ local function on_player_receive_fields(player, formname, fields)
   elseif fields.deposit then
     logistica.supplier_deposit_from_player(pos, playerName)
     show_supplier_formspec(playerName, pos)
+  elseif fields[BTN_PAGE] then
+    local totalPages = get_supplier_total_pages(pos)
+    local currPage = supplierForms[playerName].page or 1
+    show_supplier_formspec(playerName, pos, (currPage % totalPages) + 1)
   end
   return true
 end
@@ -97,7 +123,7 @@ end
 local function on_supplier_rightclick(pos, node, clicker, itemstack, pointed_thing)
   if not clicker or not clicker:is_player() then return end
   if logistica.should_hide_from_player(pos, clicker:get_player_name()) then return end
-  show_supplier_formspec(clicker:get_player_name(), pos)
+  show_supplier_formspec(clicker:get_player_name(), pos, 1)
 end
 
 local function after_place_supplier(pos, placer, itemstack)

--- a/logic/injector.lua
+++ b/logic/injector.lua
@@ -98,9 +98,14 @@ function logistica.on_injector_timer(pos, elapsed)
   local copyStack = targetInv:get_stack(targetList, targetSlot)
   local targetStackSize = copyStack:get_count()
   local numToTake = math.min(targetStackSize, maxStack)
-  copyStack:set_count(numToTake)
+  local takenStack = ItemStack(copyStack)
+  takenStack:set_count(numToTake)
+  -- remove before inserting into the network: if the target is itself a network
+  -- supplier/storage, insert_item_in_network may write back into this same live
+  -- inventory, and overwriting the slot afterwards from a stale count would clobber that
+  targetInv:remove_item(targetList, takenStack)
   local numRemaining = logistica.insert_item_in_network(
-      copyStack,
+      takenStack,
       networkId,
       false,
       not get_put_into_state(meta, 1),
@@ -109,9 +114,11 @@ function logistica.on_injector_timer(pos, elapsed)
       not get_put_into_state(meta, 4),
       true
     )
-  numRemaining = targetStackSize - numToTake + numRemaining
-  copyStack:set_count(numRemaining)
-  targetInv:set_stack(targetList, targetSlot, copyStack)
+  if numRemaining > 0 then
+    local leftoverStack = ItemStack(takenStack)
+    leftoverStack:set_count(numRemaining)
+    targetInv:add_item(targetList, leftoverStack)
+  end
 
   if numRemaining == 0
       and logistica.get_network_group_for_node_name(targetNodeName) == logistica.NETWORK_GROUPS.suppliers then

--- a/logic/reservoir.lua
+++ b/logic/reservoir.lua
@@ -212,6 +212,11 @@ function logistica.reservoir_get_liquid_name(pos)
   if not logistica.GROUPS.reservoirs.is(node.name) then return nil end
   local def = minetest.registered_nodes[node.name]
   if not def or not def.logistica or not def.logistica.liquidName then return nil end
+  if def.logistica.liquidName == LIQUID_NONE then return LIQUID_NONE end
+  -- some reservoirs (e.g. rock melter) keep one node name across all levels instead of
+  -- swapping to an "_empty" variant, so the static def alone can't tell an empty one apart
+  local meta = minetest.get_meta(pos)
+  if meta:get_int(META_LIQUID_LEVEL) == 0 then return LIQUID_NONE end
   return def.logistica.liquidName
 end
 

--- a/logic/reservoir.lua
+++ b/logic/reservoir.lua
@@ -12,6 +12,8 @@ local SOURCE_TO_NAME = {} -- { source_node_name = liquid_name }
 
 local EMPTY_BUCKET = logistica.itemstrings.empty_bucket
 local EMPTY_SUFFIX = "_empty"
+local LAVA_UNIT_ITEM = "logistica:lava_unit"
+local LAVA_LIQUID_NAME = logistica.liquids.lava
 
 local META_LIQUID_LEVEL = "liquidLevel"
 local LIQUID_NONE = ""
@@ -204,6 +206,40 @@ function logistica.reservoir_use_item_on(pos, itemstack, optNode, dryRun)
     return ItemStack(newEmptyBucket)
   end
   return nil
+end
+
+-- deposits 1 unit of lava into the reservoir at pos, same as emptying a lava bucket into it,
+-- except no item is returned since a lava unit isn't a bucket.
+-- returns true if a unit was deposited (caller is responsible for consuming 1 from the wielded stack),
+-- false if the reservoir isn't a lava reservoir (or lava-compatible empty one) or has no room
+function logistica.reservoir_deposit_lava_unit(pos, optNode, dryRun)
+  local node = optNode or minetest.get_node(pos)
+  local nodeDef = minetest.registered_nodes[node.name]
+  if not nodeDef or not nodeDef.logistica or not nodeDef.logistica.liquidName or not nodeDef.logistica.maxBuckets then return false end
+
+  local meta = minetest.get_meta(pos)
+  local liquidName = nodeDef.logistica.liquidName
+  if liquidName ~= LAVA_LIQUID_NAME and liquidName ~= LIQUID_NONE then return false end
+
+  local maxBuckets = nodeDef.logistica.maxBuckets
+  local nodeLiquidLevel = meta:get_int(META_LIQUID_LEVEL) + 1
+  if nodeLiquidLevel > maxBuckets then return false end
+
+  local newNodeName = get_liquid_reservoir_name_for(node.name, LAVA_LIQUID_NAME)
+  local newNodeDef = minetest.registered_nodes[newNodeName]
+  if not newNodeDef or not newNodeDef.logistica then return false end
+
+  if not dryRun then
+    node.param2 = logistica.reservoir_make_param2(nodeLiquidLevel, maxBuckets)
+    minetest.swap_node(pos, node)
+    if nodeLiquidLevel == 1 then -- first unit added, swap to the lava reservoir type
+      logistica.swap_node(pos, newNodeName)
+    end
+    local newLiquidDesc = logistica.reservoir_get_description_of_liquid(newNodeDef.logistica.liquidName)
+    meta:set_string("infotext", logistica.reservoir_get_description(nodeLiquidLevel, maxBuckets, newLiquidDesc))
+    meta:set_int(META_LIQUID_LEVEL, nodeLiquidLevel)
+  end
+  return true
 end
 
 -- returns the liquid name for the reservoir; or "" if there's no liquid stored, or nil if its not a reservoir

--- a/version.lua
+++ b/version.lua
@@ -1,7 +1,7 @@
 logistica.VERSION = {
   major = 2,
   minor = 0,
-  patch = 8,
+  patch = 9,
 }
 
 logistica.VERSION_STRING = logistica.VERSION.major.."."..logistica.VERSION.minor.."."..logistica.VERSION.patch


### PR DESCRIPTION
- Fix bug with trying to take from empty rock melter preventing lava being taken from network

- Fix possible bug with taking and inserting into same supply chest slots

- Make lava unit punch/rightlick on reservoir insert lava into the reservoirs

- Allow Supplier chests to handle larger sizes by showing pages

